### PR TITLE
Refactor: Use pywin32 for advanced window filtering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pynput
 pygetwindow
 mss
 pystray
+pywin32


### PR DESCRIPTION
I've replaced the `pygetwindow` library with `pywin32` to provide a more refined and intelligent window listing feature.

Key changes:
- Integrated the `pywin32` library for direct access to the Win32 API.
- The `refresh_window_list` method now uses `win32gui.EnumWindows` to iterate through windows.
- Implemented a more robust filtering logic, selecting only visible, top-level application windows with titles, using `IsWindowVisible`, `GetParent`, and the `WS_EX_APPWINDOW` style.
- Changed the data structure for storing window information from a `pygetwindow` object to a dictionary containing the title, HWND, and geometry.
- Updated dependent methods (`on_window_select`, `start_recording_from_preview`, `recording_thread`) to work with the new data structure and Win32 API calls.
- Added a minor fix for a missing `ImageTk` import.