### PR TITLE
Finalizando o novo módulo de Gravação de Tela

### DIFF
--- a/src/app/main_window.py
+++ b/src/app/main_window.py
@@ -81,9 +81,9 @@ class MainApplication(tk.Frame):
         tk.Frame(self.main_card_frame, height=1, bg="#e0e0e0").pack(fill="x", padx=40, pady=(15,10))
         content_container = tk.Frame(self.main_card_frame, bg=COR_CARD, padx=40, pady=20)
         content_container.pack(expand=True, fill="both")
-        btn1 = tk.Button(content_container, text="INICIAR CAPTURA (Shift+F9)", font=("Segoe UI", 10, "bold"), bg=COR_BOTAO, fg="white", relief=tk.FLAT, padx=20, pady=8, command=self.capture_module.start_capture_mode)
+        btn1 = tk.Button(content_container, text="INICIAR CAPTURA (Ctrl+Shift+F9)", font=("Segoe UI", 10, "bold"), bg=COR_BOTAO, fg="white", relief=tk.FLAT, padx=20, pady=8, command=self.capture_module.start_capture_mode)
         btn1.pack(pady=(5,10), fill='x')
-        btn2 = tk.Button(content_container, text="INICIAR GRAVAÇÃO (Shift+F10)", font=("Segoe UI", 10, "bold"), bg=COR_BOTAO, fg="white", relief=tk.FLAT, padx=20, pady=8, command=self.recording_module.open_recording_selection_ui)
+        btn2 = tk.Button(content_container, text="INICIAR GRAVAÇÃO (Ctrl+Shift+F10)", font=("Segoe UI", 10, "bold"), bg=COR_BOTAO, fg="white", relief=tk.FLAT, padx=20, pady=8, command=self.recording_module.open_recording_selection_ui)
         btn2.pack(pady=(5,10), fill='x')
         for btn in [btn1, btn2]:
             btn.bind("<Enter>", lambda e: e.widget.config(bg=COR_BOTAO_HOVER))

--- a/src/core/hotkeys.py
+++ b/src/core/hotkeys.py
@@ -2,11 +2,11 @@ from pynput import keyboard
 
 def key_listener_thread_proc(capture_module, recording_module, root_window):
     current_keys = set()
-    CAPTURE_COMBO = {keyboard.Key.shift, keyboard.Key.f9}
-    RECORD_COMBO = {keyboard.Key.shift, keyboard.Key.f10}
+    CAPTURE_COMBO = {keyboard.Key.ctrl, keyboard.Key.shift, keyboard.Key.f9}
+    RECORD_COMBO = {keyboard.Key.ctrl, keyboard.Key.shift, keyboard.Key.f10}
 
     def on_press(key):
-        if key in {keyboard.Key.shift, keyboard.Key.f9, keyboard.Key.f10}:
+        if key in {keyboard.Key.ctrl, keyboard.Key.shift, keyboard.Key.f9, keyboard.Key.f10}:
             current_keys.add(key)
 
         if CAPTURE_COMBO.issubset(current_keys):


### PR DESCRIPTION
- Altera os atalhos de captura e gravação para usar Ctrl+Shift+F9 e Ctrl+Shift+F10, evitando conflitos com atalhos do Windows.
- Atualiza o texto dos botões na interface principal para refletir os novos atalhos.
- Confirma que a lógica de seleção de janela para gravação, com confirmação em dois cliques, está implementada corretamente, finalizando o fluxo do "Modo Manto das Sombras".