### PR TITLE
Corrigi uma disparidade de comportamento que você apontou entre o bot…

### DIFF
--- a/src/core/hotkeys.py
+++ b/src/core/hotkeys.py
@@ -33,7 +33,7 @@ def parse_hotkey_string(hotkey_string):
     return "+".join(pynput_parts)
 
 
-def key_listener_thread_proc(capture_module, recording_module, root_window):
+def key_listener_thread_proc(capture_module, recording_module, root_window, main_app_instance):
     config = configparser.ConfigParser()
     config.read(CONFIG_FILE)
 
@@ -50,7 +50,10 @@ def key_listener_thread_proc(capture_module, recording_module, root_window):
 
         state = recording_module.state
         if state == "idle":
-            root_window.after(0, recording_module.enter_preparation_mode)
+            # Consulta o estado do checkbox na UI principal
+            record_all = main_app_instance.record_all_screens_var.get()
+            # Inicia o modo de preparação passando o estado correto
+            root_window.after(0, recording_module.enter_preparation_mode, record_all)
         elif state == "preparing":
             # The quality profile is now read inside the recording thread
             root_window.after(0, recording_module.start_recording_mode)

--- a/src/main.py
+++ b/src/main.py
@@ -59,7 +59,7 @@ def main():
 
     listener_thread = threading.Thread(
         target=key_listener_thread_proc,
-        args=(capture_module, recording_module, root),
+        args=(capture_module, recording_module, root, main_app),
         daemon=True
     )
     listener_thread.start()


### PR DESCRIPTION
…ão "Iniciar Gravação" da UI e o atalho de teclado F10.

Anteriormente, o atalho F10 iniciava o modo de preparação de gravação sem verificar o estado do checkbox "Gravar todas as telas", o que resultava em um comportamento diferente do botão da UI, que lia o estado corretamente.

Para resolver isso, implementei as seguintes alterações no seu código:
1. Passei a referência da instância da aplicação principal (`main_app`) para a thread do listener de teclado.
2. Atualizei a thread do listener de teclado (`key_listener_thread_proc`) para aceitar esta referência.
3. Agora, ao acionar o atalho F10, o listener utiliza a referência da aplicação para consultar o estado do checkbox "Gravar todas as telas" antes de iniciar o modo de preparação. Isso garante que ambos os métodos de ativação (UI e atalho) se comportem de forma idêntica.