### PR TITLE
feat: Unify capture and record preparation UI

### DIFF
--- a/src/core/capture.py
+++ b/src/core/capture.py
@@ -3,10 +3,10 @@ import mss
 from PIL import Image
 from datetime import datetime
 from tkinter import simpledialog
-from tkinter import Toplevel
 import re
 
-from ..ui.capture_indicator import CaptureIndicator
+from ..ui.preparation_indicator import PreparationIndicator
+from ..ui.preparation_mode import PreparationOverlayManager
 from ..ui.dialogs import show_success_dialog
 
 def is_valid_foldername(name):
@@ -14,66 +14,72 @@ def is_valid_foldername(name):
     if re.search(r'[<>:"/\\|?*]', name): return False
     return True
 
-def trigger_flash_animation(parent_window):
-    flash_window = Toplevel(parent_window)
-    flash_window.overrideredirect(True)
-    flash_window.attributes('-topmost', True)
-    try:
-        monitor_dims = mss.mss().monitors[1]
-    except IndexError:
-        monitor_dims = mss.mss().monitors[0]
-    flash_window.geometry(f"{monitor_dims['width']}x{monitor_dims['height']}+{monitor_dims['left']}+{monitor_dims['top']}")
-    flash_window.attributes('-alpha', 0.0)
-    flash_window.configure(bg='white')
-    flash_window.attributes('-alpha', 0.3)
-    flash_window.after(100, lambda: flash_window.destroy())
-
 class ScreenCaptureModule:
     def __init__(self, root, save_path):
         self.root = root
         self.save_path = save_path
-        self.capture_indicator = CaptureIndicator(self.root, self)
-        self.capturing = False
-        self.screenshots = []
+        self.is_preparing = False
+        self.overlay_manager = None
+        # The indicator is created here but used by the overlay manager
+        self.indicator = PreparationIndicator(self.root)
 
-    def start_capture_mode(self):
-        if self.capturing:
+    def enter_preparation_mode(self):
+        if self.is_preparing:
             return
-        self.capturing = True
-        self.screenshots = []
-        self.capture_indicator.update_count(0)
-        self.capture_indicator.show()
-        self.root.withdraw()
 
-    def take_screenshot(self):
-        if self.capturing:
-            try:
-                trigger_flash_animation(self.root)
-                with mss.mss() as sct:
-                    sct_img = sct.grab(sct.monitors[0])
-                    img = Image.frombytes("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX")
-                    self.screenshots.append(img)
-                self.capture_indicator.update_count(len(self.screenshots))
-            except Exception as e:
-                print(f"Erro de Captura: {e}")
+        self.is_preparing = True
+        self.overlay_manager = PreparationOverlayManager(
+            self.root,
+            self.indicator,
+            indicator_text="Mire na tela e pressione F9 para Capturar",
+            inactive_text="Esta tela não será capturada"
+        )
+        self.overlay_manager.start()
 
-    def stop_capture_mode(self):
-        if not self.capturing:
+    def exit_preparation_mode(self):
+        if not self.is_preparing:
             return
-        self.capturing = False
-        self.capture_indicator.hide()
-        if self.screenshots:
-            folder_name_input = simpledialog.askstring("Salvar Evidências", "Digite o nome da pasta para as capturas:", parent=self.root)
-            base_folder_name = folder_name_input if folder_name_input and is_valid_foldername(folder_name_input) else f"Evidencias_Captura_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+
+        if self.overlay_manager:
+            self.overlay_manager.destroy()
+            self.overlay_manager = None
+
+        self.is_preparing = False
+        self.root.deiconify()
+
+    def take_screenshot(self, monitor):
+        if not self.is_preparing:
+            return
+
+        try:
+            # The overlay manager is destroyed after the screenshot is taken
+            with mss.mss() as sct:
+                sct_img = sct.grab(monitor)
+                img = Image.frombytes("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX")
+
+            # --- Save the single screenshot ---
+            folder_name_input = simpledialog.askstring(
+                "Salvar Evidência",
+                "Digite o nome da pasta para a captura:",
+                parent=self.root
+            )
+            base_folder_name = folder_name_input if folder_name_input and is_valid_foldername(folder_name_input) else f"Evidencia_Captura_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
             target_save_path = os.path.join(self.save_path, base_folder_name)
             os.makedirs(target_save_path, exist_ok=True)
-            for i, img in enumerate(self.screenshots):
-                img.save(os.path.join(target_save_path, f"evidencia_{i+1}.png"))
-            try:
-                os.startfile(target_save_path)
-            except Exception as e:
-                print(f"Não foi possível abrir a pasta: {e}")
-            success_message = f"{len(self.screenshots)} capturas salvas."
-            show_success_dialog(self.root, success_message, target_save_path, os.path.abspath(target_save_path))
-        self.screenshots.clear()
-        self.root.deiconify()
+
+            filename = f"captura_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.png"
+            full_path = os.path.join(target_save_path, filename)
+            img.save(full_path)
+
+            show_success_dialog(
+                self.root,
+                "Captura salva com sucesso!",
+                target_save_path,
+                os.path.abspath(full_path)
+            )
+
+        except Exception as e:
+            print(f"Erro de Captura: {e}")
+        finally:
+            # Ensure we always exit preparation mode
+            self.exit_preparation_mode()

--- a/src/core/hotkeys.py
+++ b/src/core/hotkeys.py
@@ -41,11 +41,22 @@ def key_listener_thread_proc(capture_module, recording_module, root_window, main
     record_hotkey_str = config.get('Hotkeys', 'record', fallback='F10')
 
     def on_activate_capture():
-        if not recording_module.is_recording:
-            root_window.after(0, capture_module.start_capture_mode)
+        # Prevent capture from starting if a recording is in progress.
+        if recording_module.state != "idle":
+            return
+
+        if capture_module.is_preparing:
+            # Second press: take the screenshot
+            active_monitor = capture_module.overlay_manager.get_active_monitor()
+            if active_monitor:
+                root_window.after(0, capture_module.take_screenshot, active_monitor)
+        else:
+            # First press: enter preparation mode
+            root_window.after(0, capture_module.enter_preparation_mode)
 
     def on_activate_record():
-        if capture_module.capturing:
+        # Prevent recording from starting if a capture is in preparation.
+        if capture_module.is_preparing:
             return
 
         state = recording_module.state

--- a/src/core/recording.py
+++ b/src/core/recording.py
@@ -5,15 +5,16 @@ from datetime import datetime
 import cv2
 import mss
 import numpy as np
-from PIL import Image, ImageTk
+from PIL import Image
 from pynput.mouse import Controller as MouseController
 import tkinter as tk
-from tkinter import Toplevel, messagebox
+from tkinter import messagebox
 import configparser
 from ..config.settings import CONFIG_FILE
 
-from ..ui.recording_indicator import RecordingIndicator
+from ..ui.preparation_indicator import PreparationIndicator
 from ..ui.dialogs import show_success_dialog
+from ..ui.preparation_mode import PreparationOverlayManager
 
 
 class ScreenRecordingModule:
@@ -23,221 +24,74 @@ class ScreenRecordingModule:
         self.state = "idle"  # Can be "idle", "preparing", "recording"
         self.out = None
         self.start_time = None
-        self.recording_indicator = RecordingIndicator(self.root, self)
+        self.indicator = PreparationIndicator(self.root)
+        self.indicator.module_instance = self # For legacy `show` method
         self.sct = mss.mss()
         self.thread_gravacao = None
-
-        # --- NEW: Attributes for dynamic focus and animation ---
-        self.preparation_overlays = {}  # Dict to map monitor_id to overlay info
-        self.active_monitor_for_recording = None
-        self.focus_check_id = None # ID for the focus checking loop
-        # No need for self.animation_ids, it will be handled inside the overlay_info dict
-        # --- END NEW ---
+        self.overlay_manager = None
+        self.should_record_all_screens = False
 
     @property
     def is_recording(self):
         return self.state == "recording"
 
-    # --- MODIFIED: enter_preparation_mode ---
     def enter_preparation_mode(self, record_all_screens=False):
         print(f"[RUNA DE DEPURAÇÃO] Modo de Preparação iniciado com record_all_screens = {record_all_screens}")
-        self.should_record_all_screens = record_all_screens # Armazena o estado na instância
+        self.should_record_all_screens = record_all_screens
         if self.state != "idle":
             return
 
         if record_all_screens:
-            # Bypassa o modo de preparação e inicia a gravação diretamente
             self.start_recording_mode()
             return
 
         self.state = "preparing"
-        self.root.withdraw()
+        # The overlay manager will hide the root window
+        self.overlay_manager = PreparationOverlayManager(
+            self.root,
+            self.indicator,
+            indicator_text="Mire na tela e pressione F10 para Iniciar/Parar",
+            inactive_text="Esta tela não será gravada."
+        )
+        self.overlay_manager.start()
 
-        mouse_pos = MouseController().position
-        # We add a unique ID to each monitor dictionary
-        monitors = [{**m, 'id': i} for i, m in enumerate(self.sct.monitors[1:])]
-
-        # Determine initial active monitor
-        initial_active_monitor = None
-        for m in monitors:
-            if m['left'] <= mouse_pos[0] < m['left'] + m['width'] and \
-               m['top'] <= mouse_pos[1] < m['top'] + m['height']:
-                initial_active_monitor = m
-                break
-
-        if not initial_active_monitor and monitors:
-            initial_active_monitor = monitors[0]
-
-        self.active_monitor_for_recording = initial_active_monitor
-
-        # Create overlays for all monitors
-        for monitor in monitors:
-            if monitor['id'] == self.active_monitor_for_recording['id']:
-                # Active monitor gets the preparation indicator
-                self.recording_indicator.show_preparation_mode(monitor)
-            else:
-                # Inactive monitors get the dark, noisy overlay
-                self._create_inactive_overlay(monitor)
-
-        # Start tracking mouse movement
-        self.focus_check_id = self.root.after(250, self.update_active_screen_focus)
-
-    # --- NEW: update_active_screen_focus ---
-    def update_active_screen_focus(self):
-        if self.state != "preparing":
-            return # Stop loop if not in preparation mode
-
-        mouse_pos = MouseController().position
-        monitors = [{**m, 'id': i} for i, m in enumerate(self.sct.monitors[1:])]
-
-        new_active_monitor = None
-        for m in monitors:
-            if m['left'] <= mouse_pos[0] < m['left'] + m['width'] and \
-               m['top'] <= mouse_pos[1] < m['top'] + m['height']:
-                new_active_monitor = m
-                break
-
-        if new_active_monitor and new_active_monitor['id'] != self.active_monitor_for_recording['id']:
-            self.swap_focus(new_active_monitor)
-
-        # Reschedule the check
-        self.focus_check_id = self.root.after(250, self.update_active_screen_focus)
-
-    # --- NEW: swap_focus ---
-    def swap_focus(self, new_monitor):
-        old_monitor = self.active_monitor_for_recording
-
-        # Deactivate the old monitor: hide indicator and create inactive overlay
-        self.recording_indicator.hide_preparation_mode()
-        self._create_inactive_overlay(old_monitor)
-
-        # Activate the new monitor: destroy inactive overlay and show indicator
-        if new_monitor['id'] in self.preparation_overlays:
-            overlay_info = self.preparation_overlays.pop(new_monitor['id'])
-            if overlay_info['animation_id']:
-                self.root.after_cancel(overlay_info['animation_id'])
-            overlay_info['window'].destroy()
-
-        self.active_monitor_for_recording = new_monitor
-        self.recording_indicator.show_preparation_mode(new_monitor)
-
-    # --- NEW: animate_static_effect ---
-    def animate_static_effect(self, monitor_id):
-        if self.state != "preparing" or monitor_id not in self.preparation_overlays:
-            return
-
-        overlay_info = self.preparation_overlays[monitor_id]
-        canvas = overlay_info['canvas']
-        image_item = overlay_info['image_item']
-
-        if not canvas.winfo_exists() or not image_item:
-            return
-
-        w, h = overlay_info['window'].winfo_width(), overlay_info['window'].winfo_height()
-        if w == 1 or h == 1: # Window might not be sized yet
-            self.root.after(50, self.animate_static_effect, monitor_id)
-            return
-
-        try:
-            tile_size = 128
-            # Generate a smaller noise pattern and tile it, which is more performant
-            noise_pattern = np.random.randint(0, 35, (tile_size, tile_size), dtype=np.uint8)
-            noise_pil = Image.fromarray(noise_pattern, 'L')
-            full_img = Image.new('L', (w, h))
-            for y in range(0, h, tile_size):
-                for x in range(0, w, tile_size):
-                    full_img.paste(noise_pil, (x, y))
-
-            new_photo = ImageTk.PhotoImage(image=full_img)
-            canvas.itemconfig(image_item, image=new_photo)
-            canvas.image_ref = new_photo  # Crucial: prevent garbage collection
-
-            # Schedule the next frame
-            animation_id = self.root.after(100, self.animate_static_effect, monitor_id)
-            self.preparation_overlays[monitor_id]['animation_id'] = animation_id
-        except Exception as e:
-            # This can happen if the window is destroyed during the process
-            print(f"Error during static animation: {e}")
-
-    # --- MODIFIED: _create_inactive_overlay (to include animation start) ---
-    def _create_inactive_overlay(self, monitor):
-        overlay = Toplevel(self.root)
-        overlay.overrideredirect(True)
-        overlay.geometry(f"{monitor['width']}x{monitor['height']}+{monitor['left']}+{monitor['top']}")
-        overlay.wm_attributes("-topmost", True)
-        overlay.wm_attributes("-alpha", 0.7)
-
-        canvas = tk.Canvas(overlay, bg="black", highlightthickness=0)
-        canvas.pack(fill="both", expand=True)
-
-        w, h = monitor['width'], monitor['height']
-
-        image_item = canvas.create_image(0, 0, anchor="nw") # Create an empty image item first
-
-        try:
-            logo_image = Image.open("assets/logo.png").resize((120, 120), Image.Resampling.LANCZOS)
-            logo_tk = ImageTk.PhotoImage(logo_image)
-            canvas.create_image(w/2, h/2 - 50, image=logo_tk)
-            canvas.logo_ref = logo_tk
-        except Exception as e:
-            print(f"Não foi possível carregar o logo para a sobreposição: {e}")
-
-        canvas.create_text(w/2, h/2 + 40, text="Esta tela não será gravada.",
-                            fill="white", font=("Segoe UI", 16, "bold"), justify="center")
-
-        self.preparation_overlays[monitor['id']] = {
-            'window': overlay,
-            'canvas': canvas,
-            'image_item': image_item,
-            'animation_id': None
-        }
-
-        # Start the animation loop
-        self.root.after(10, self.animate_static_effect, monitor['id'])
-
-    # --- MODIFIED: _destroy_preparation_overlays ---
-    def _destroy_preparation_overlays(self):
-        if self.focus_check_id:
-            self.root.after_cancel(self.focus_check_id)
-            self.focus_check_id = None
-
-        for monitor_id, overlay_info in list(self.preparation_overlays.items()):
-            if overlay_info['animation_id']:
-                self.root.after_cancel(overlay_info['animation_id'])
-            overlay_info['window'].destroy()
-        self.preparation_overlays.clear()
-
-        self.recording_indicator.hide_preparation_mode()
-
-    # --- MODIFIED: start_recording_mode ---
     def start_recording_mode(self, quality_profile="high"):
+        active_monitor = None
         if self.state == "preparing":
-            self._destroy_preparation_overlays()
+            if not self.overlay_manager:
+                print("Error: In preparing state but no overlay manager found.")
+                self.state = "idle"
+                return
+            active_monitor = self.overlay_manager.get_active_monitor()
+            self.overlay_manager.destroy()
+            self.overlay_manager = None
         elif self.state != "idle":
             return
 
         self.state = "recording"
-        self.root.withdraw() # Garante que a janela principal esteja oculta
+        self.root.withdraw()
         time.sleep(0.2)
 
-        target_monitor = self.active_monitor_for_recording if not self.should_record_all_screens else None
-        # O último argumento para o thread é removido, já que o thread usará o atributo da classe
+        target_monitor = active_monitor if not self.should_record_all_screens else None
         self.thread_gravacao = threading.Thread(target=self.recording_thread, args=(target_monitor, quality_profile), daemon=True)
         self.thread_gravacao.start()
 
-        self.recording_indicator.show()
+        # The indicator needs to know which monitor to appear on.
+        indicator_monitor = active_monitor if active_monitor else self.sct.monitors[1]
+        self.indicator.show(indicator_monitor)
         self.start_time = time.time()
         self.update_chronometer_loop()
 
-    # --- MODIFIED: stop_recording ---
     def stop_recording(self):
         if self.state == "recording":
             self.state = "idle"
-            self.recording_indicator.hide()
+            self.indicator.hide()
             self.root.deiconify()
         elif self.state == "preparing":
             self.state = "idle"
-            self._destroy_preparation_overlays()
+            if self.overlay_manager:
+                self.overlay_manager.destroy()
+                self.overlay_manager = None
             self.root.deiconify()
 
     def recording_thread(self, target_to_record, quality_profile):
@@ -266,6 +120,11 @@ class ScreenRecordingModule:
             width, height = total_width, max_height
             recording_fps = 15.0
         else:
+            if not target_to_record:
+                print("Error: Target monitor for recording is not set.")
+                self.root.after(0, self.stop_recording)
+                return
+
             original_width, original_height = target_to_record['width'], target_to_record['height']
             if quality_profile == "compact":
                 MAX_WIDTH, MAX_HEIGHT = 1280, 720
@@ -310,47 +169,32 @@ class ScreenRecordingModule:
                         monitors_to_capture = sct.monitors[1:]
                         combined_frame = np.zeros((height, width, 3), dtype=np.uint8)
                         current_x_offset = 0
-
-                        # Define a origem do Desktop Virtual para o cálculo do cursor
                         virtual_screen_left = sct.monitors[0]['left']
                         virtual_screen_top = sct.monitors[0]['top']
-
                         for monitor in monitors_to_capture:
                             sct_img = sct.grab(monitor)
                             frame_np = np.array(sct_img)
                             h_m, w_m, _ = frame_np.shape
-
-                            # Converte de BGRA para BGR
                             frame_bgr = cv2.cvtColor(frame_np, cv2.COLOR_BGRA2BGR)
                             combined_frame[0:h_m, current_x_offset:current_x_offset + w_m] = frame_bgr
                             current_x_offset += w_m
-
                         final_frame_pil = Image.fromarray(cv2.cvtColor(combined_frame, cv2.COLOR_BGR2RGB))
-
                         if cursor_img:
                             mouse_pos = mouse_controller.position
-                            # Coordenadas do cursor relativas ao canto superior esquerdo do desktop virtual
                             cursor_x = mouse_pos[0] - virtual_screen_left
                             cursor_y = mouse_pos[1] - virtual_screen_top
                             final_frame_pil.paste(cursor_img, (cursor_x, cursor_y), cursor_img)
-
                         self.out.write(cv2.cvtColor(np.array(final_frame_pil), cv2.COLOR_RGB2BGR))
-
-                    else:  # Lógica original para uma única tela
-                        print("[RUNA DE DEPURAÇÃO] Forja ativada em modo Focado (uma tela).")
+                    else:
                         capture_area = target_to_record
                         sct_img = sct.grab(capture_area)
                         frame_np = np.array(sct_img)
-
                         original_width, original_height = target_to_record['width'], target_to_record['height']
-
                         if (original_width, original_height) != (width, height):
                             frame_np_resized = cv2.resize(frame_np, (width, height), interpolation=cv2.INTER_AREA)
                         else:
                             frame_np_resized = frame_np
-
                         frame_pil = Image.fromarray(cv2.cvtColor(frame_np_resized, cv2.COLOR_BGRA2RGB))
-
                         if cursor_img:
                             mouse_pos = mouse_controller.position
                             cursor_x_in_capture = mouse_pos[0] - capture_area['left']
@@ -358,18 +202,14 @@ class ScreenRecordingModule:
                             scaled_cursor_x = int(cursor_x_in_capture * (width / original_width))
                             scaled_cursor_y = int(cursor_y_in_capture * (height / original_height))
                             frame_pil.paste(cursor_img, (scaled_cursor_x, scaled_cursor_y), cursor_img)
-
                         self.out.write(cv2.cvtColor(np.array(frame_pil), cv2.COLOR_RGB2BGR))
-
                 except Exception as e:
                     print(f"Erro durante o loop de gravação: {e}")
-                    self.state = "idle" # Changed from is_recording = False to avoid race conditions
-
+                    self.state = "idle"
                 sleep_time = (1/recording_fps) - (time.time() - loop_start_time)
                 if sleep_time > 0: time.sleep(sleep_time)
 
         if self.out: self.out.release()
-
         def finalize_on_main_thread():
             if os.path.exists(filename) and os.path.getsize(filename) > 0:
                 show_success_dialog(self.root, "Gravação salva.", os.path.dirname(filename), filename)
@@ -379,5 +219,5 @@ class ScreenRecordingModule:
 
     def update_chronometer_loop(self):
         if self.is_recording and self.start_time is not None:
-            self.recording_indicator.update_time(time.time() - self.start_time)
+            self.indicator.update_time(time.time() - self.start_time)
             self.root.after(1000, self.update_chronometer_loop)

--- a/src/ui/preparation_mode.py
+++ b/src/ui/preparation_mode.py
@@ -1,0 +1,187 @@
+import tkinter as tk
+from tkinter import Toplevel
+import mss
+import numpy as np
+from PIL import Image, ImageTk
+from pynput.mouse import Controller as MouseController
+
+class PreparationOverlayManager:
+    """
+    Manages the visual preparation mode for screen capture and recording.
+    This includes creating overlays on inactive screens, managing focus
+    switching between monitors, and showing a readiness indicator on the
+    active screen.
+    """
+    def __init__(self, root, indicator, indicator_text, inactive_text="This screen will not be used.", logo_path="assets/logo.png"):
+        self.root = root
+        self.indicator = indicator
+        self.indicator_text = indicator_text
+        self.inactive_text = inactive_text
+        self.logo_path = logo_path
+
+        self.sct = mss.mss()
+        self.overlays = {}
+        self.active_monitor = None
+        self.focus_check_id = None
+        self.is_running = False
+
+    def get_active_monitor(self):
+        """Returns the dictionary of the currently active monitor."""
+        return self.active_monitor
+
+    def start(self):
+        """Starts the preparation mode."""
+        if self.is_running:
+            return
+        self.is_running = True
+        self.root.withdraw()
+
+        mouse_pos = MouseController().position
+        monitors = [{**m, 'id': i} for i, m in enumerate(self.sct.monitors[1:])]
+
+        # Determine initial active monitor
+        initial_active_monitor = None
+        for m in monitors:
+            if m['left'] <= mouse_pos[0] < m['left'] + m['width'] and \
+               m['top'] <= mouse_pos[1] < m['top'] + m['height']:
+                initial_active_monitor = m
+                break
+
+        if not initial_active_monitor and monitors:
+            initial_active_monitor = monitors[0]
+
+        self.active_monitor = initial_active_monitor
+
+        # Create overlays for all monitors
+        for monitor in monitors:
+            if self.active_monitor and monitor['id'] == self.active_monitor['id']:
+                # Active monitor gets the preparation indicator
+                self.indicator.show_preparation_mode(monitor, self.indicator_text)
+            else:
+                # Inactive monitors get the dark, noisy overlay
+                self._create_inactive_overlay(monitor)
+
+        # Start tracking mouse movement
+        self.focus_check_id = self.root.after(250, self._update_active_screen_focus)
+
+    def destroy(self):
+        """Destroys all preparation UI elements and stops loops."""
+        if not self.is_running:
+            return
+        self.is_running = False
+
+        if self.focus_check_id:
+            self.root.after_cancel(self.focus_check_id)
+            self.focus_check_id = None
+
+        for monitor_id, overlay_info in list(self.overlays.items()):
+            if overlay_info.get('animation_id'):
+                self.root.after_cancel(overlay_info['animation_id'])
+            overlay_info['window'].destroy()
+        self.overlays.clear()
+
+        self.indicator.hide_preparation_mode()
+        # We don't deiconify the root window here, the calling module should do that.
+
+    def _update_active_screen_focus(self):
+        if not self.is_running:
+            return
+
+        mouse_pos = MouseController().position
+        monitors = [{**m, 'id': i} for i, m in enumerate(self.sct.monitors[1:])]
+
+        new_active_monitor = None
+        for m in monitors:
+            if m['left'] <= mouse_pos[0] < m['left'] + m['width'] and \
+               m['top'] <= mouse_pos[1] < m['top'] + m['height']:
+                new_active_monitor = m
+                break
+
+        if new_active_monitor and self.active_monitor and new_active_monitor['id'] != self.active_monitor['id']:
+            self._swap_focus(new_active_monitor)
+
+        self.focus_check_id = self.root.after(250, self._update_active_screen_focus)
+
+    def _swap_focus(self, new_monitor):
+        old_monitor = self.active_monitor
+
+        # Deactivate the old monitor: hide indicator and create inactive overlay
+        self.indicator.hide_preparation_mode()
+        if old_monitor:
+            self._create_inactive_overlay(old_monitor)
+
+        # Activate the new monitor: destroy inactive overlay and show indicator
+        if new_monitor['id'] in self.overlays:
+            overlay_info = self.overlays.pop(new_monitor['id'])
+            if overlay_info.get('animation_id'):
+                self.root.after_cancel(overlay_info['animation_id'])
+            overlay_info['window'].destroy()
+
+        self.active_monitor = new_monitor
+        self.indicator.show_preparation_mode(new_monitor, self.indicator_text)
+
+
+    def _create_inactive_overlay(self, monitor):
+        overlay = Toplevel(self.root)
+        overlay.overrideredirect(True)
+        overlay.geometry(f"{monitor['width']}x{monitor['height']}+{monitor['left']}+{monitor['top']}")
+        overlay.wm_attributes("-topmost", True)
+        overlay.wm_attributes("-alpha", 0.7)
+
+        canvas = tk.Canvas(overlay, bg="black", highlightthickness=0)
+        canvas.pack(fill="both", expand=True)
+
+        w, h = monitor['width'], monitor['height']
+        image_item = canvas.create_image(0, 0, anchor="nw")
+
+        try:
+            logo_image = Image.open(self.logo_path).resize((120, 120), Image.Resampling.LANCZOS)
+            logo_tk = ImageTk.PhotoImage(logo_image)
+            canvas.create_image(w/2, h/2 - 50, image=logo_tk)
+            canvas.logo_ref = logo_tk
+        except Exception as e:
+            print(f"Could not load logo for overlay: {e}")
+
+        canvas.create_text(w/2, h/2 + 40, text=self.inactive_text,
+                            fill="white", font=("Segoe UI", 16, "bold"), justify="center")
+
+        self.overlays[monitor['id']] = {
+            'window': overlay,
+            'canvas': canvas,
+            'image_item': image_item,
+            'animation_id': None
+        }
+        self.root.after(10, self._animate_static_effect, monitor['id'])
+
+    def _animate_static_effect(self, monitor_id):
+        if not self.is_running or monitor_id not in self.overlays:
+            return
+
+        overlay_info = self.overlays[monitor_id]
+        canvas = overlay_info['canvas']
+
+        if not canvas.winfo_exists():
+            return
+
+        w, h = overlay_info['window'].winfo_width(), overlay_info['window'].winfo_height()
+        if w <= 1 or h <= 1:
+            self.root.after(50, self._animate_static_effect, monitor_id)
+            return
+
+        try:
+            tile_size = 128
+            noise_pattern = np.random.randint(0, 35, (tile_size, tile_size), dtype=np.uint8)
+            noise_pil = Image.fromarray(noise_pattern, 'L')
+            full_img = Image.new('L', (w, h))
+            for y in range(0, h, tile_size):
+                for x in range(0, w, tile_size):
+                    full_img.paste(noise_pil, (x, y))
+
+            new_photo = ImageTk.PhotoImage(image=full_img)
+            canvas.itemconfig(overlay_info['image_item'], image=new_photo)
+            canvas.image_ref = new_photo
+
+            animation_id = self.root.after(100, self._animate_static_effect, monitor_id)
+            self.overlays[monitor_id]['animation_id'] = animation_id
+        except Exception as e:
+            print(f"Error during static animation: {e}")


### PR DESCRIPTION
Refactors the Screen Capture module to use the same visual preparation mode as the Screen Recording module, providing a consistent user experience.

- Extracts the common UI logic for screen overlays, focus tracking, and readiness indicators into a new reusable `PreparationOverlayManager` class in `src/ui/preparation_mode.py`.
- Refactors `ScreenRecordingModule` to use the new manager, ensuring no regressions.
- Overhauls `ScreenCaptureModule` to adopt a stateful, two-step workflow (prepare, then capture), replacing the old session-based logic.
- Updates the F9 hotkey to manage the new preparation flow.
- Creates a more generic `PreparationIndicator` to be shared between features.