### PR TITLE
feat: Add Escape key to cancel preparation mode

### DIFF
--- a/src/core/hotkeys.py
+++ b/src/core/hotkeys.py
@@ -76,9 +76,17 @@ def key_listener_thread_proc(capture_module, recording_module, root_window, main
         parsed_capture_hotkey = parse_hotkey_string(capture_hotkey_str)
         parsed_record_hotkey = parse_hotkey_string(record_hotkey_str)
 
+        def on_escape():
+            """Cancels any active preparation mode."""
+            if capture_module.is_preparing:
+                root_window.after(0, capture_module.exit_preparation_mode)
+            elif recording_module.is_preparing:
+                root_window.after(0, recording_module.exit_preparation_mode)
+
         hotkeys = {
             parsed_capture_hotkey: on_activate_capture,
-            parsed_record_hotkey: on_activate_record
+            parsed_record_hotkey: on_activate_record,
+            '<esc>': on_escape
         }
 
         with keyboard.GlobalHotKeys(hotkeys) as h:

--- a/src/core/recording.py
+++ b/src/core/recording.py
@@ -35,6 +35,22 @@ class ScreenRecordingModule:
     def is_recording(self):
         return self.state == "recording"
 
+    @property
+    def is_preparing(self):
+        return self.state == "preparing"
+
+    def exit_preparation_mode(self):
+        if self.state != "preparing":
+            return
+
+        if self.overlay_manager:
+            self.overlay_manager.destroy()
+            self.overlay_manager = None
+
+        self.state = "idle"
+        # Ensure the main window is visible again
+        self.root.deiconify()
+
     def enter_preparation_mode(self, record_all_screens=False):
         print(f"[RUNA DE DEPURAÇÃO] Modo de Preparação iniciado com record_all_screens = {record_all_screens}")
         self.should_record_all_screens = record_all_screens


### PR DESCRIPTION
This commit introduces the ability for you to cancel the screen capture or recording preparation mode by pressing the Escape key.

- A new `exit_preparation_mode` method has been added to the `ScreenRecordingModule` to cleanly exit the preparation state, destroy the overlay, and reset the module's state.
- The `hotkeys.py` listener now includes a global hotkey for the `<esc>` key.
- When the Escape key is pressed, the new hotkey callback checks if either the capture or recording module is in its `is_preparing` state and, if so, calls the appropriate `exit_preparation_mode` method.

This provides a universal and intuitive way for you to back out of an action, improving the application's responsiveness and user flow.