### PR TITLE
I've completed the refactor to use absolute imports for PyInstaller c…

### DIFF
--- a/src/app/main_window.py
+++ b/src/app/main_window.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 
-from ..ui.settings_window import SettingsWindow
+from src.ui.settings_window import SettingsWindow
 
 COR_FUNDO_JANELA = "#f0f5f0"
 COR_CARD = "#ffffff"

--- a/src/core/capture.py
+++ b/src/core/capture.py
@@ -7,9 +7,9 @@ from tkinter import simpledialog
 import re
 
 # Assuming these are the correct locations from the original file
-from ..ui.preparation_mode import PreparationOverlayManager
-from ..ui.dialogs import show_success_dialog
-from ..ui.capture_indicator import CaptureIndicator
+from src.ui.preparation_mode import PreparationOverlayManager
+from src.ui.dialogs import show_success_dialog
+from src.ui.capture_indicator import CaptureIndicator
 
 def is_valid_foldername(name):
     """ Helper function to validate folder names. """

--- a/src/core/hotkeys.py
+++ b/src/core/hotkeys.py
@@ -1,6 +1,6 @@
 import configparser
 from pynput import keyboard
-from ..config.settings import CONFIG_FILE
+from src.config.settings import CONFIG_FILE
 
 def parse_hotkey_string(hotkey_string):
     """

--- a/src/core/recording.py
+++ b/src/core/recording.py
@@ -10,11 +10,11 @@ from pynput.mouse import Controller as MouseController
 import tkinter as tk
 from tkinter import messagebox
 import configparser
-from ..config.settings import CONFIG_FILE
+from src.config.settings import CONFIG_FILE
 
-from ..ui.preparation_indicator import PreparationIndicator
-from ..ui.dialogs import show_success_dialog
-from ..ui.preparation_mode import PreparationOverlayManager
+from src.ui.preparation_indicator import PreparationIndicator
+from src.ui.dialogs import show_success_dialog
+from src.ui.preparation_mode import PreparationOverlayManager
 
 
 class ScreenRecordingModule:

--- a/src/main.py
+++ b/src/main.py
@@ -1,15 +1,31 @@
+import sys
+import os
+
+# Este é o Feitiço de Autoconhecimento.
+# Ele adiciona a pasta raiz do projeto ao caminho do Python,
+# permitindo que o executável encontre seus próprios módulos.
+if getattr(sys, 'frozen', False):
+    # Se estiver rodando como um executável compilado pelo PyInstaller
+    project_root = os.path.dirname(sys.executable)
+else:
+    # Se estiver rodando como um script normal
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+# Adiciona a raiz ao início do caminho de busca de módulos
+sys.path.insert(0, project_root)
+
+# --- O RESTANTE DOS IMPORTS VEM DEPOIS DESTE BLOCO ---
+# Exemplo: from src.app.main_window import MainApplication
 import tkinter as tk
 import threading
 import ctypes
-import os
-import sys
-from .app.main_window import MainApplication
-from .core.capture import ScreenCaptureModule
-from .core.recording import ScreenRecordingModule
-from .core.hotkeys import key_listener_thread_proc
-from .app.tray_icon import setup_tray_icon
-from .config.settings import load_app_config
-from .ui.settings_window import SettingsWindow
+from src.app.main_window import MainApplication
+from src.core.capture import ScreenCaptureModule
+from src.core.recording import ScreenRecordingModule
+from src.core.hotkeys import key_listener_thread_proc
+from src.app.tray_icon import setup_tray_icon
+from src.config.settings import load_app_config
+from src.ui.settings_window import SettingsWindow
 
 def resource_path(relative_path):
     try:

--- a/src/ui/settings_window.py
+++ b/src/ui/settings_window.py
@@ -3,7 +3,7 @@ from tkinter import Toplevel, filedialog, messagebox, ttk
 import os
 from tkinter import font as tkfont
 
-from ..config.settings import save_app_config
+from src.config.settings import save_app_config
 
 COR_FUNDO_JANELA = "#f0f5f0"
 COR_TEXTO_PRINCIPAL = "#005a36"


### PR DESCRIPTION
…ompatibility.

I modified `sys.path` in `src/main.py` to make the application aware of the project's root directory, especially when running as a compiled executable.

I then converted all relative imports throughout the project to absolute imports based on the `src` directory. This ensures that modules can be located correctly in both development and production (compiled) environments, resolving potential `ImportError` issues.