### PR TITLE
Refatoração: Movi a função resource_path para o módulo utils.py

### DIFF
--- a/src/app/main_window.py
+++ b/src/app/main_window.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 
-from src.main import resource_path
+from src.utils import resource_path
 from src.ui.settings_window import SettingsWindow
 
 COR_FUNDO_JANELA = "#f0f5f0"

--- a/src/app/tray_icon.py
+++ b/src/app/tray_icon.py
@@ -3,7 +3,7 @@ from pystray import MenuItem as item, Icon as icon, Menu
 from PIL import Image
 import os
 
-from src.main import resource_path
+from src.utils import resource_path
 
 def setup_tray_icon(root, capture_module, recording_module, app_config):
 

--- a/src/core/recording.py
+++ b/src/core/recording.py
@@ -11,7 +11,7 @@ import tkinter as tk
 from tkinter import messagebox
 import configparser
 from src.config.settings import CONFIG_FILE
-from src.main import resource_path
+from src.utils import resource_path
 
 from src.ui.preparation_indicator import PreparationIndicator
 from src.ui.dialogs import show_success_dialog

--- a/src/main.py
+++ b/src/main.py
@@ -26,13 +26,7 @@ from src.core.hotkeys import key_listener_thread_proc
 from src.app.tray_icon import setup_tray_icon
 from src.config.settings import load_app_config
 from src.ui.settings_window import SettingsWindow
-
-def resource_path(relative_path):
-    try:
-        base_path = sys._MEIPASS
-    except Exception:
-        base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    return os.path.join(base_path, "assets", relative_path)
+from src.utils import resource_path
 
 def main():
     try:

--- a/src/ui/preparation_mode.py
+++ b/src/ui/preparation_mode.py
@@ -4,7 +4,7 @@ import mss
 import numpy as np
 from PIL import Image, ImageTk
 from pynput.mouse import Controller as MouseController
-from src.main import resource_path
+from src.utils import resource_path
 
 class PreparationOverlayManager:
     """

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,14 @@
+# Este é o grimório comum, um lugar para feitiços e utilitários compartilhados.
+import sys
+import os
+
+def resource_path(relative_path):
+    """ Obtém o caminho absoluto para um recurso, funciona para dev e para o PyInstaller """
+    try:
+        # PyInstaller cria uma pasta temporária e armazena o caminho em _MEIPASS
+        base_path = sys._MEIPASS
+    except Exception:
+        # Se não estiver no modo PyInstaller, use o caminho do arquivo
+        base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+    return os.path.join(base_path, "assets", relative_path)


### PR DESCRIPTION
Movi a função utilitária `resource_path` de `src/main.py` para um novo arquivo `src/utils.py`.

Esta alteração corrige um problema de importação circular que ocorria porque `main.py` importava módulos (como `main_window.py`) que, por sua vez, precisavam importar `resource_path` de `main.py`.

Ao mover `resource_path` para um módulo de utilitários dedicado, quebrei o ciclo de dependência e melhorei a modularidade do código. Também atualizei todas as referências à função em todo o projeto para apontar para a nova localização em `src/utils.py`.