### PR TITLE
Refactor: Apply defensive reset strategy

### DIFF
--- a/src/core/capture.py
+++ b/src/core/capture.py
@@ -36,10 +36,12 @@ class ScreenCaptureModule:
 
     def start_capture_session(self):
         """ Starts the capture session, showing overlays and the initial command bar. """
+        # Defensive: Ensure the session starts clean.
+        self.screenshots = []
+
         if self.is_in_session:
             return
 
-        self.screenshots = []
         self.is_in_session = True
 
         # This part handles displaying overlays on all screens
@@ -180,5 +182,5 @@ class ScreenCaptureModule:
                 session_save_path
             )
         finally:
-            # Ensure the list is cleared
-            self.screenshots = []
+            # Defensive: Ensure the list is cleared to prevent memory leaks or state carry-over.
+            self.screenshots.clear()

--- a/src/ui/capture_indicator.py
+++ b/src/ui/capture_indicator.py
@@ -55,6 +55,14 @@ class CaptureIndicator(Toplevel):
 
     def show_preparation_mode(self, monitor_info, text):
         """Exibe o indicador em um modo de preparação na tela especificada."""
+        # Defensive: Reset the counter label if it exists, to avoid showing stale data.
+        if self.counter_label.winfo_exists():
+            self.counter_label.config(text="Total de Capturas: 0")
+            # Also, reset the UI to its initial state
+            self.counter_label.pack_forget()
+            self.end_button.pack_forget()
+            self.instruction_label.pack(side="left", padx=(0, 15))
+
         self.instruction_label.config(text=text) # Reutiliza o label de instrução para o modo de preparação
         self.update_idletasks()
 


### PR DESCRIPTION
This commit implements a defensive programming strategy to ensure the application state is robustly reset between capture sessions.

Key changes:
- In `src/core/capture.py`:
  - The `start_capture_session` method now explicitly clears the screenshots list at the very beginning to guarantee a clean state.
  - The `end_capture_session` method now uses `screenshots.clear()` within a `finally` block for a more robust cleanup.
- In `src/ui/capture_indicator.py`:
  - The `show_preparation_mode` method now resets the session counter and UI to its initial state, preventing stale data from being displayed.