### PR TITLE
Refactor: Sincronizar chamadas de método e assinaturas de função

### DIFF
--- a/src/core/capture.py
+++ b/src/core/capture.py
@@ -41,12 +41,11 @@ class ScreenCaptureModule:
         self.overlay_manager = PreparationOverlayManager(self.root, self.capture_indicator, "Pressione F9 para capturar a tela ativa")
         self.overlay_manager.start()
 
-    def take_screenshot(self):
+    def take_screenshot(self, active_monitor):
         """Tira um screenshot da tela ativa e comanda a atualização do indicador."""
         if not self.is_in_session:
             return
 
-        active_monitor = self.overlay_manager.get_active_monitor()
         if not active_monitor:
             return
 

--- a/src/ui/preparation_mode.py
+++ b/src/ui/preparation_mode.py
@@ -57,7 +57,7 @@ class PreparationOverlayManager:
         for monitor in monitors:
             if self.active_monitor and monitor['id'] == self.active_monitor['id']:
                 # Active monitor gets the preparation indicator
-                self.indicator.show_preparation_mode(monitor, self.indicator_text)
+                self.indicator.show_initial_state(monitor)
             else:
                 # Inactive monitors get the dark, noisy overlay
                 self._create_inactive_overlay(monitor)
@@ -81,7 +81,7 @@ class PreparationOverlayManager:
             overlay_info['window'].destroy()
         self.overlays.clear()
 
-        self.indicator.hide_preparation_mode()
+        self.indicator.hide()
         # We don't deiconify the root window here, the calling module should do that.
 
     def _update_active_screen_focus(self):
@@ -107,7 +107,7 @@ class PreparationOverlayManager:
         old_monitor = self.active_monitor
 
         # Deactivate the old monitor: hide indicator and create inactive overlay
-        self.indicator.hide_preparation_mode()
+        self.indicator.hide()
         if old_monitor:
             self._create_inactive_overlay(old_monitor)
 
@@ -119,7 +119,7 @@ class PreparationOverlayManager:
             overlay_info['window'].destroy()
 
         self.active_monitor = new_monitor
-        self.indicator.show_preparation_mode(new_monitor, self.indicator_text)
+        self.indicator.show_initial_state(new_monitor)
 
 
     def _create_inactive_overlay(self, monitor):


### PR DESCRIPTION
Alinha as chamadas de método no PreparationOverlayManager com os novos nomes no CaptureIndicator e modifica a assinatura de take_screenshot para aceitar o monitor ativo como argumento.