### PR TITLE
Fix TypeError and AttributeError in core modules

### DIFF
--- a/src/core/capture.py
+++ b/src/core/capture.py
@@ -32,8 +32,8 @@ class ScreenCaptureModule:
         self.is_in_session = True
         
         # Cria e inicia o gerenciador de sobreposição, passando a si mesmo como módulo de controle
-        self.overlay_manager = PreparationOverlayManager(self.root, self.indicator, self)
-        self.overlay_manager.start_capture()
+        self.overlay_manager = PreparationOverlayManager(self.root, self.indicator, "Take Screenshot (F1)", "Recording will start on this screen.")
+        self.overlay_manager.start()
 
     def take_screenshot(self):
         """Tira um screenshot da tela ativa, adiciona à lista e comanda a atualização do indicador."""
@@ -81,7 +81,8 @@ class ScreenCaptureModule:
                 parent=self.root
             )
             
-            save_path = self.app_config.get('Paths', 'DefaultSaveLocation')
+            config_parser = self.app_config["config_parser_obj"]
+            save_path = config_parser.get('Paths', 'DefaultSaveLocation')
             base_folder_name = folder_name_input if folder_name_input and is_valid_foldername(folder_name_input) else f"Evidencias_Captura_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
             
             session_save_path = os.path.join(save_path, base_folder_name)

--- a/src/core/recording.py
+++ b/src/core/recording.py
@@ -100,8 +100,8 @@ class ScreenRecordingModule:
 
         # --- 2. CASCATA DE CONTINGÊNCIA DE CODECS ---
         
-        config = self.app_config
-        quality_profile = config.get('Recording', 'quality', fallback='high')
+        config_parser = self.app_config["config_parser_obj"]
+        quality_profile = config_parser.get('Recording', 'quality', fallback='high')
         
         if quality_profile == 'high':
             rec_fps = 15.0


### PR DESCRIPTION
This commit addresses two separate but related issues:

1.  A `TypeError` in `recording.py` and `capture.py` caused by attempting to call `.get()` on a dictionary instead of the nested `ConfigParser` object. The code has been updated to correctly access `self.app_config['config_parser_obj']` before retrieving configuration values.

2.  An `AttributeError` in `capture.py` where `self.overlay_manager.start_capture()` was called, but the method did not exist. This has been corrected to call the `start()` method instead. Additionally, the arguments passed to the `PreparationOverlayManager` constructor have been corrected to be strings as expected, instead of a module object.