### PR TITLE
feat: Implementa reset de contador e tela cheia inicial

### DIFF
--- a/src/core/capture.py
+++ b/src/core/capture.py
@@ -157,8 +157,16 @@ class ScreenCaptureModule:
         # Show the main window again if it was hidden
         self.root.deiconify()
 
+        # O FEITIÇO DO ZERAMENTO VISUAL
+        # Garante que o placar da caçada seja limpo para o próximo herói.
+        if self.capture_indicator:
+            self.capture_indicator.reset_view()
+            self.capture_indicator.hide()
+
         # Proceed to save if screenshots were taken
         if not self.screenshots:
+            # Limpa a lista mesmo se não houver capturas, para garantir consistência
+            self.screenshots = []
             return
 
         try:

--- a/src/main.py
+++ b/src/main.py
@@ -39,14 +39,15 @@ def main():
 
     root = tk.Tk()
     root.withdraw()  # Oculta a janela principal inicialmente
-    root.state('zoomed') # Inicia a janela maximizada
+    root.attributes('-fullscreen', True)  # Inicia em modo tela cheia real
 
-    # Função para sair do modo maximizado/tela cheia
-    def exit_zoom(event=None):
-        root.state('normal')
+    # Função para sair do modo tela cheia
+    def exit_fullscreen(event=None):
+        root.attributes('-fullscreen', False)
+        root.state('zoomed') # Opcional: maximizar após sair da tela cheia
 
     # Vinculando a tecla Escape a esta função
-    root.bind('<Escape>', exit_zoom)
+    root.bind('<Escape>', exit_fullscreen)
 
     root.title("Sentinela Unimed")
     root.protocol("WM_DELETE_WINDOW", root.withdraw)

--- a/src/ui/capture_indicator.py
+++ b/src/ui/capture_indicator.py
@@ -41,6 +41,13 @@ class CaptureIndicator(Toplevel):
         # Atualiza o texto do contador em todas as chamadas
         self.counter_label.config(text=f"Total de Capturas: {count}")
 
+    def reset_view(self):
+        """Redefine o indicador para o seu estado inicial."""
+        self.counter_label.pack_forget()
+        self.end_button.pack_forget()
+        self.instruction_label.pack(side="left", padx=(0, 15))
+        self.instruction_label.config(text="Pressione F9 para capturar a Tela Ativa")
+
 
     def show(self):
         self.update_idletasks()


### PR DESCRIPTION
Este commit aborda duas de suas solicitações:

1. O contador de capturas de tela agora é redefinido corretamente ao final de cada sessão. Isso foi feito adicionando um método `reset_view` ao `CaptureIndicator` e garantindo que ele seja chamado quando a sessão de captura termina.

2. A janela de boas-vindas agora inicia em modo de tela cheia real (borderless) para uma experiência de usuário mais imersiva, conforme solicitado. Você pode sair do modo de tela cheia pressionando a tecla Escape.